### PR TITLE
Enable configurable video framerate instead of fixed 30fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ import { compress } from 'expo-image-and-video-compressor';
 const result = await compress(videoUri, {
   bitrate: 2_500_000,   // 2.5 Mbps
   maxSize: 1080,         // Scale down to 1080p
+  fps: 24,               // Optional: cap output framerate
   codec: 'h264',         // or 'hevc' for ~40% smaller output
   speed: 'ultrafast',    // Fastest encoding
 }, (progress) => {
@@ -193,6 +194,7 @@ Compresses a video file using the device's hardware encoder.
 |--------|------|---------|-------------|
 | `bitrate` | `number` | Auto | Target bitrate in bits per second. Auto-calculated from resolution when omitted. |
 | `maxSize` | `number` | `1080` | Maximum output dimension (width or height) in pixels. Aspect ratio is preserved. |
+| `fps` | `number` | Source fps | Target output framerate. When omitted, the source framerate is preserved when available. |
 | `codec` | `'h264' \| 'hevc'` | `'h264'` | Output video codec. HEVC produces ~40% smaller files but requires iOS 11+ / Android 5+. |
 | `speed` | `'ultrafast' \| 'fast' \| 'balanced'` | `'ultrafast'` | Encoding speed preset. Faster = larger file, slower = better compression ratio. |
 | `minimumFileSizeForCompress` | `number` | `0` | Skip compression if the source file is smaller than this value (in bytes). |

--- a/android/src/main/java/expo/modules/bayutvideocompressor/BayutVideoCompressorModule.kt
+++ b/android/src/main/java/expo/modules/bayutvideocompressor/BayutVideoCompressorModule.kt
@@ -31,6 +31,7 @@ class BayutVideoCompressorModule : Module() {
                 val config = VideoCompressor.CompressConfig(
                     maxSize = (options["maxSize"] as? Number)?.toInt() ?: 1080,
                     bitrate = (options["bitrate"] as? Number)?.toInt() ?: 0,
+                    fps = (options["fps"] as? Number)?.toInt() ?: 0,
                     codec = options["codec"] as? String ?: "h264",
                     speed = options["speed"] as? String ?: "ultrafast",
                 )

--- a/android/src/main/java/expo/modules/bayutvideocompressor/VideoCompressor.kt
+++ b/android/src/main/java/expo/modules/bayutvideocompressor/VideoCompressor.kt
@@ -25,6 +25,7 @@ class VideoCompressor(private val context: Context) {
     data class CompressConfig(
         val maxSize: Int = 1080,
         val bitrate: Int = 0,
+        val fps: Int = 0,
         val codec: String = "h264",
         val speed: String = "ultrafast",
     )
@@ -81,12 +82,23 @@ class VideoCompressor(private val context: Context) {
         val videoTrackIndex = findTrack(extractor, true)
         if (videoTrackIndex < 0) throw IllegalStateException("No video track found")
         val audioTrackIndex = findTrack(extractor, false)
+        extractor.selectTrack(videoTrackIndex)
+        val inputFormat = extractor.getTrackFormat(videoTrackIndex)
+        val sourceFps = try {
+            inputFormat.getInteger(MediaFormat.KEY_FRAME_RATE)
+        } catch (e: Exception) { 0 }
+        val targetFps = when {
+            config.fps > 0 -> config.fps
+            sourceFps > 0 -> sourceFps
+            else -> 30
+        }
+        Log.i(TAG, "Target fps: $targetFps${if (sourceFps > 0) " (source: $sourceFps)" else ""}")
 
         // Set up encoder
         val outputFormat = MediaFormat.createVideoFormat(mimeType, outputWidth, outputHeight).apply {
             setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
             setInteger(MediaFormat.KEY_BIT_RATE, outputBitrate)
-            setInteger(MediaFormat.KEY_FRAME_RATE, 30)
+            setInteger(MediaFormat.KEY_FRAME_RATE, targetFps)
             setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, I_FRAME_INTERVAL)
             setInteger(MediaFormat.KEY_BITRATE_MODE, MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -103,8 +115,6 @@ class VideoCompressor(private val context: Context) {
 
         // GL pipeline: decoder → SurfaceTexture → GL → eglPresentationTimeANDROID → encoder
         // Required for correct timestamps and bitrate control
-        extractor.selectTrack(videoTrackIndex)
-        val inputFormat = extractor.getTrackFormat(videoTrackIndex)
         val decoder = MediaCodec.createDecoderByType(inputFormat.getString(MediaFormat.KEY_MIME)!!)
 
         val outputSurface = OutputSurface(encoderInputSurface, outputWidth, outputHeight)
@@ -118,19 +128,15 @@ class VideoCompressor(private val context: Context) {
         // are already in the correct orientation. Setting the hint would cause
         // double rotation (e.g. portrait → landscape).
 
-        // Frame dropping: if source fps > 30, skip excess frames to save processing time
-        val TARGET_FPS = 30
-        val sourceFps = try {
-            inputFormat.getInteger(MediaFormat.KEY_FRAME_RATE)
-        } catch (e: Exception) { 0 }
-        val frameDropEnabled = sourceFps > TARGET_FPS
-        // Interval between target frames in microseconds (e.g. 33333us for 30fps)
-        val targetFrameIntervalUs = if (frameDropEnabled) 1_000_000L / TARGET_FPS else 0L
+        // Frame dropping: if source fps > target fps, skip excess frames.
+        val frameDropEnabled = sourceFps > 0 && targetFps > 0 && sourceFps > targetFps
+        // Interval between target frames in microseconds.
+        val targetFrameIntervalUs = if (frameDropEnabled) 1_000_000L / targetFps else 0L
         var nextTargetPtsUs = 0L
         var droppedFrames = 0
 
         if (frameDropEnabled) {
-            Log.i(TAG, "Frame dropping: ${sourceFps}fps → ${TARGET_FPS}fps (will skip ~${((1.0 - TARGET_FPS.toFloat()/sourceFps) * 100).toInt()}% of frames)")
+            Log.i(TAG, "Frame dropping: ${sourceFps}fps → ${targetFps}fps (will skip ~${((1.0 - targetFps.toFloat()/sourceFps) * 100).toInt()}% of frames)")
         }
 
         var videoMuxTrack = -1

--- a/ios/BayutVideoCompressorModule.swift
+++ b/ios/BayutVideoCompressorModule.swift
@@ -23,6 +23,7 @@ public class BayutVideoCompressorModule: Module {
 
       let maxSize = options["maxSize"] as? Int ?? 1080
       let bitrate = options["bitrate"] as? Int ?? 0
+      let fps = options["fps"] as? Int ?? 0
       let codec = options["codec"] as? String ?? "h264"
       let speed = options["speed"] as? String ?? "ultrafast"
       let minimumFileSize = options["minimumFileSizeForCompress"] as? Double ?? 0
@@ -81,6 +82,7 @@ public class BayutVideoCompressorModule: Module {
         outputWidth: Int(outputWidth),
         outputHeight: Int(outputHeight),
         outputBitrate: outputBitrate,
+        fps: fps,
         codec: codec,
         speed: speed,
         uuid: uuid,
@@ -232,6 +234,7 @@ public class BayutVideoCompressorModule: Module {
     outputWidth: Int,
     outputHeight: Int,
     outputBitrate: Int,
+    fps: Int,
     codec: String,
     speed: String,
     uuid: String,
@@ -256,6 +259,11 @@ public class BayutVideoCompressorModule: Module {
       AVVideoAverageBitRateKey: outputBitrate,
       AVVideoProfileLevelKey: profileLevel,
     ]
+
+    if fps > 0 {
+      compressionProps[AVVideoExpectedSourceFrameRateKey] = fps
+      compressionProps[AVVideoMaxKeyFrameIntervalKey] = fps
+    }
 
     // Speed optimizations
     if speed == "ultrafast" {

--- a/src/BayutVideoCompressor.types.ts
+++ b/src/BayutVideoCompressor.types.ts
@@ -43,6 +43,13 @@ export interface CompressOptions {
   codec?: CompressionCodec;
 
   /**
+   * Target output framerate (frames per second).
+   * When omitted, the compressor keeps the source framerate when available.
+   * Example: 24, 30, 60
+   */
+  fps?: number;
+
+  /**
    * Compression speed preset.
    * Default: 'ultrafast'
    */

--- a/src/BayutVideoCompressorModule.ts
+++ b/src/BayutVideoCompressorModule.ts
@@ -6,7 +6,7 @@ declare class BayutVideoCompressorModule extends NativeModule<BayutVideoCompress
   /**
    * Compress a video file with hardware acceleration.
    * @param fileUrl - File URI of the video to compress
-   * @param options - Compression options (bitrate, maxSize, codec, speed)
+   * @param options - Compression options (bitrate, maxSize, fps, codec, speed)
    * @returns Promise resolving to the compressed file URI
    */
   compress(fileUrl: string, options: CompressOptions): Promise<string>;


### PR DESCRIPTION
### Summary
- Added a new optional `fps` option to `CompressOptions` so callers can control output framerate.
- Updated Android compression pipeline to stop forcing 30fps:
  - Uses `fps` when provided.
  - Otherwise preserves source framerate when available (fallbacks only when missing).
  - Adjusted frame-drop logic to target the configured/preserved fps instead of hardcoded 30.
- Updated iOS compression settings to honor `fps` when provided via AVFoundation compression properties.
- Updated docs and examples in `README.md` to include the new `fps` option.

### Why
- The compressor previously enforced a fixed 30fps output, which could reduce smoothness for high-fps inputs and limited caller control.
- This change makes framerate behavior configurable and preserves source characteristics by default.

### Notes
- No breaking API changes; `fps` is optional.
- Existing callers continue to work without modification.